### PR TITLE
Use official parcel package as peerDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "posthtml-inline-assets": "^3.0.0"
   },
   "peerDependencies": {
-    "parcel": "^1.9.4"
+    "parcel-bundler": "^1.9.4"
   },
   "bugs": {
     "url": "https://github.com/shff/parcel-plugin-inliner/issues"


### PR DESCRIPTION
`parcel-bundler` is what https://parceljs.org/getting_started.html says to install. With `parcel-bundler` installed npm shows the following warning:

```
npm WARN parcel-plugin-inliner@1.0.6 requires a peer of parcel@^1.9.4 but none is installed. You must install peer dependencies yourself.
```

But everything works anyway :)